### PR TITLE
Correct typo issue at Localizable.strings

### DIFF
--- a/libraries/Foundations/Strings/Sources/Strings/Resources/en.lproj/Localizable.strings
+++ b/libraries/Foundations/Strings/Sources/Strings/Resources/en.lproj/Localizable.strings
@@ -1486,7 +1486,7 @@
 // MARK: Local agent
 
 "_local_agent_server_error_title" = "Server error";
-"_local_agent_server_error_message" = "An error occured on the server. Please connect to another server.";
+"_local_agent_server_error_message" = "An error occurred on the server. Please connect to another server.";
 
 "_local_agent_policy_violation_error_title" = "Policy violation";
 "_local_agent_policy_violation_error_message" = "You are not allowed to connect to the server. Choose a different server or upgrade your plan.";


### PR DESCRIPTION
Correct typo issue from `occured` to `occurred` at `Localizable.strings`. 