### PR TITLE
Apply Hermes DNS when storing refreshed macOS WireGuard config

### DIFF
--- a/apps/macos/ProtonVPN/Scenes/Common/Services/AppSessionManager.swift
+++ b/apps/macos/ProtonVPN/Scenes/Common/Services/AppSessionManager.swift
@@ -196,7 +196,7 @@ final class AppSessionManagerImplementation: AppSessionRefresherImplementation, 
         $userTier.withLock { $0 = credentials.maxTier }
 
         if let clientConfig = properties.clientConfig {
-            propertiesManager.wireguardConfig = clientConfig.wireGuardConfig
+            propertiesManager.wireguardConfig = clientConfig.wireGuardConfig.refreshConfig()
             propertiesManager.smartProtocolConfig = clientConfig.smartProtocolConfig
             propertiesManager.featureFlags = clientConfig.featureFlags
             propertiesManager.maintenanceServerRefreshIntereval = clientConfig.serverRefreshInterval

--- a/apps/macos/ProtonVPNTests/Tests/AppSessionManagerImplementationTests.swift
+++ b/apps/macos/ProtonVPNTests/Tests/AppSessionManagerImplementationTests.swift
@@ -24,6 +24,7 @@ import CommonNetworkingTestSupport
 import Dependencies
 import Domain
 import Ergonomics
+import Hermes
 import LegacyCommon
 import Localization
 import Persistence
@@ -411,6 +412,130 @@ final class AppSessionManagerImplementationTests: XCTestCase {
         return withExtendedLifetime(subscribeAndReturnToken()) { _ in
             operation()
         }
+    }
+}
+
+final class AppSessionManagerHermesDNSTests: XCTestCase {
+    private var alertService: AppSessionManagerAlertServiceMock!
+    private var appStateManager: AppStateManagerMock!
+    private var updateChecker: UpdateCheckerMock!
+    private var repository: ServerRepository!
+
+    override func invokeTest() {
+        repository = withDependencies {
+            $0.databaseConfiguration = .withTestExecutor(databaseType: .ephemeral)
+        } operation: {
+            ServerRepositoryKey.liveValue
+        }
+
+        withDependencies {
+            $0.serverRepository = repository
+        } operation: {
+            super.invokeTest()
+        }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        alertService = AppSessionManagerAlertServiceMock()
+        appStateManager = AppStateManagerMock()
+        updateChecker = UpdateCheckerMock()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        alertService = nil
+        appStateManager = nil
+        updateChecker = nil
+        repository = nil
+    }
+
+    func testSilentLoginAppliesHermesDNSWhenStoringWireGuardClientConfig() async throws {
+        let propertiesManager = try await performSilentLoginWithHermesConfig(
+            isHermesEnabled: true,
+            hermesAuthorization: .success
+        )
+
+        XCTAssertEqual(propertiesManager.wireguardConfig.dnsServers, ["127.0.0.1", "10.2.0.1"])
+    }
+
+    func testSilentLoginDoesNotApplyHermesDNSWhenHermesIsDisabled() async throws {
+        let propertiesManager = try await performSilentLoginWithHermesConfig(
+            isHermesEnabled: false,
+            hermesAuthorization: .success
+        )
+
+        XCTAssertEqual(propertiesManager.wireguardConfig.dnsServers, ["10.2.0.1"])
+    }
+
+    func testSilentLoginDoesNotApplyHermesDNSWhenHermesIsNotAllowed() async throws {
+        let propertiesManager = try await performSilentLoginWithHermesConfig(
+            isHermesEnabled: true,
+            hermesAuthorization: .failure(.requiresUpgrade)
+        )
+
+        XCTAssertEqual(propertiesManager.wireguardConfig.dnsServers, ["10.2.0.1"])
+    }
+
+    private func performSilentLoginWithHermesConfig(
+        isHermesEnabled: Bool,
+        hermesAuthorization: FeatureAuthorizationResult
+    ) async throws -> PropertiesManagerMock {
+        let propertiesManager = PropertiesManagerMock()
+        let authKeychain = AuthKeychainHandleMock()
+        authKeychain.credentials = testAuthCredentials
+        let vpnKeychain = VpnKeychainMock()
+        let vpnCredentials = VpnKeychainMock.vpnCredentials(planName: "plus", maxTier: .paidTier)
+        let customResolver = try HermesResolver(ipAddress: "127.0.0.1")
+        @Dependency(\.hermesClient) var hermesClient
+        defer {
+            let activeResolvers = hermesClient.activeHermesResolvers().wrappedValue
+            for index in activeResolvers.indices.reversed() {
+                _ = hermesClient.removeHermesResolver(index)
+            }
+            hermesClient.setIsEnabled(false)
+        }
+
+        try await withDependencies {
+            $0.authKeychain = authKeychain
+            $0.vpnKeychain = vpnKeychain
+            $0.propertiesManager = propertiesManager
+            $0.serverRepository = repository
+            $0.featureAuthorizerProvider = FeatureAuthorizerKey.constant(hermesAuthorization)
+            $0.announcementRefresher = AnnouncementRefresherMock()
+
+            let existingResolvers = $0.hermesClient.activeHermesResolvers().wrappedValue
+            for index in existingResolvers.indices.reversed() {
+                _ = $0.hermesClient.removeHermesResolver(index)
+            }
+            $0.hermesClient.setIsEnabled(isHermesEnabled)
+            _ = $0.hermesClient.addHermesResolver(customResolver)
+
+            $0.vpnApiClient.vpnProperties = { _, _, _ in
+                VpnProperties(
+                    serverInfo: .notModified(since: nil),
+                    streamingServices: nil,
+                    vpnCredentials: vpnCredentials,
+                    location: nil,
+                    clientConfig: ClientConfig.defaultClientConfigForTests,
+                    user: nil,
+                    addresses: nil
+                )
+            }
+        } operation: {
+            let factory = ManagerFactoryMock(
+                alertService: alertService,
+                appStateManager: appStateManager,
+                updateChecker: updateChecker
+            )
+            let manager = AppSessionManagerImplementation(factory: factory)
+
+            try await manager.attemptSilentLogIn()
+        }
+
+        return propertiesManager
     }
 }
 


### PR DESCRIPTION
## Summary

Apply Hermes DNS settings when macOS stores refreshed WireGuard client config during session refresh.

## Background

The macOS session refresh path was storing `clientConfig.wireGuardConfig` directly after fetching VPN properties. That bypassed the existing `refreshConfig()` step used by iOS and by the macOS Hermes update event path.

As a result, active Hermes/custom DNS resolvers could be missing from the stored WireGuard config until a later Hermes update event refreshed it.

## Changes

- In `apps/macos/ProtonVPN/Scenes/Common/Services/AppSessionManager.swift`, update the macOS session refresh path to store `clientConfig.wireGuardConfig.refreshConfig()` instead of the raw `clientConfig.wireGuardConfig`
- This aligns the macOS `retrieveProperties()` behavior with the existing iOS session refresh path and the macOS Hermes update event path
- In `apps/macos/ProtonVPNTests/Tests/AppSessionManagerImplementationTests.swift`, add `AppSessionManagerHermesDNSTests` to cover the silent login/session refresh behavior

## Verification

The new regression tests are included in this PR and exercise the session refresh behavior with mocked app dependencies:

- auth and VPN keychains are populated with test credentials
- `vpnApiClient.vpnProperties` returns `ClientConfig.defaultClientConfigForTests`
- Hermes is configured with an active custom resolver, `127.0.0.1`
- `attemptSilentLogIn()` is run
- the stored `propertiesManager.wireguardConfig.dnsServers` value is asserted

Covered scenarios:

- Hermes enabled and authorized: stores `["127.0.0.1", "10.2.0.1"]`
- Hermes disabled: stores `["10.2.0.1"]`
- Hermes enabled but not authorized: stores `["10.2.0.1"]`

## Testing

- `git diff --check`
- Targeted macOS regression test: `AppSessionManagerHermesDNSTests`

I verified the targeted test locally in a configured macOS/Xcode project environment.

The test is included in this PR and can be run from the PR branch with:

```sh
xcodebuild test \
  -workspace ProtonVPN.xcworkspace \
  -scheme ProtonVPNmacOSTests \
  -destination 'platform=macOS' \
  -only-testing:ProtonVPNmacOSTests/AppSessionManagerHermesDNSTests
```

Manual signed-app VPN tunnel verification was not run.
